### PR TITLE
Fix composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require-dev": {
     "phpunit/phpunit": "~4.0",
     "phpspec/phpspec": "~2.1",
-    "fabpot/php-cs-fixer": "~2.0",
+    "fabpot/php-cs-fixer": "~1.0",
     "orchestra/testbench": "~3.0",
     "fzaninotto/faker": "~1.5"
   },

--- a/composer.json
+++ b/composer.json
@@ -39,5 +39,5 @@
   "config":{
     "preferred-install": "dist"
   },
-  "minimum-stability" : "dev"
+  "minimum-stability" : "stable"
 }


### PR DESCRIPTION
Require stable dependencies for better support and security. 
The package [fabpot/php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases) not have a version that matches with the `~2.0` version constraint, require the latest release from `~1.0` instead.