### PR TITLE
changed the auth primary key in migrations to get from auth model 

### DIFF
--- a/src/resources/migrations/2015_02_23_161103_create_defender_role_user_table.php
+++ b/src/resources/migrations/2015_02_23_161103_create_defender_role_user_table.php
@@ -12,7 +12,7 @@ class CreateDefenderRoleUserTable extends Migration
     {
         Schema::create(config('defender.role_user_table', 'role_user'), function (Blueprint $table) {
             $table->integer('user_id')->unsigned()->index();
-            $table->foreign('user_id')->references('id')->on(config('auth.table', 'users'))->onDelete('cascade');
+            $table->foreign('user_id')->references(app(config("auth.model"))->getKeyName())->on(config('auth.table', 'users'))->onDelete('cascade');
 
             $table->integer(config('defender.role_key', 'role_id'))->unsigned()->index();
             $table->foreign(config('defender.role_key', 'role_id'))->references('id')

--- a/src/resources/migrations/2015_02_23_161104_create_defender_permission_user_table.php
+++ b/src/resources/migrations/2015_02_23_161104_create_defender_permission_user_table.php
@@ -12,7 +12,7 @@ class CreateDefenderPermissionUserTable extends Migration
     {
         Schema::create(config('defender.permission_user_table', 'permission_user'), function (Blueprint $table) {
             $table->integer('user_id')->unsigned()->index();
-            $table->foreign('user_id')->references('id')->on(config('auth.table', 'users'))->onDelete('cascade');
+            $table->foreign('user_id')->references(app(config("auth.model"))->getKeyName())->on(config('auth.table', 'users'))->onDelete('cascade');
 
             $table->integer(config('defender.permission_key', 'permission_id'))->unsigned()->index();
             $table->foreign(config('defender.permission_key', 'permission_id'))->references('id')


### PR DESCRIPTION
changing in migrations to get the primary key name from the user model, instead the static string 'id'
This is for the people that wants to customise their colunms names.