### PR TITLE
Creating Role and Permission classes from config file

### DIFF
--- a/README-pt_BR.md
+++ b/README-pt_BR.md
@@ -616,3 +616,46 @@ public function foo()
 	];
 }
 ```
+
+## Usando modelos personalizados para Role e Permission
+
+Para utilizar suas próprias classes para os modelos Role e Permission, primeiramente defina os valores para as chaves `role_model` e `permission_model` no arquivo de configuração `defender.php`.
+
+A seguir dois exemplos de como devem ser implementados os modelos de Role e Permission para MongoDB usando o driver [jenssegers/laravel-mongodb](https://github.com/jenssegers/laravel-mongodb):
+
+    <?php
+    
+    // Role model
+    
+    namespace Pordio;
+    
+    use Jenssegers\Mongodb\Eloquent\Model;
+    use Artesaos\Defender\Traits\Models\Role;
+    use Artesaos\Defender\Contracts\Role as RoleInterface;
+    
+    /**
+     * Class Role.
+     */
+    class Role extends Model implements RoleInterface {
+        use Role;
+    }
+
+    <?php
+    
+    // Permission model
+    
+    namespace Pordio;
+    
+    use Jenssegers\Mongodb\Eloquent\Model;
+    use Artesaos\Defender\Traits\Models\Permission;
+    use Artesaos\Defender\Contracts\Permission as PermissionInterface;
+    
+    /**
+     * Class Permission.
+     */
+    class Permission extends Model implements PermissionInterface
+    {
+        use Permission;    
+    }
+
+Você deve utilizar os traits corretos e cada classe deve implementar o contrato de interface correspondente.

--- a/README-pt_BR.md
+++ b/README-pt_BR.md
@@ -623,11 +623,12 @@ Para utilizar suas próprias classes para os modelos Role e Permission, primeira
 
 A seguir dois exemplos de como devem ser implementados os modelos de Role e Permission para MongoDB usando o driver [jenssegers/laravel-mongodb](https://github.com/jenssegers/laravel-mongodb):
 
+```php
     <?php
     
     // Role model
     
-    namespace Pordio;
+    namespace App;
     
     use Jenssegers\Mongodb\Eloquent\Model;
     use Artesaos\Defender\Traits\Models\Role;
@@ -640,11 +641,14 @@ A seguir dois exemplos de como devem ser implementados os modelos de Role e Perm
         use Role;
     }
 
+```
+
+```php
     <?php
     
     // Permission model
     
-    namespace Pordio;
+    namespace App;
     
     use Jenssegers\Mongodb\Eloquent\Model;
     use Artesaos\Defender\Traits\Models\Permission;
@@ -657,5 +661,6 @@ A seguir dois exemplos de como devem ser implementados os modelos de Role e Perm
     {
         use Permission;    
     }
+```
 
 Você deve utilizar os traits corretos e cada classe deve implementar o contrato de interface correspondente.

--- a/README.md
+++ b/README.md
@@ -744,7 +744,7 @@ Following are two examples of how Role and Permission models must be implemented
     
     // Role model
     
-    namespace Pordio;
+    namespace App;
     
     use Jenssegers\Mongodb\Eloquent\Model;
     use Artesaos\Defender\Traits\Models\Role;
@@ -763,7 +763,7 @@ Following are two examples of how Role and Permission models must be implemented
     
     // Permission model
     
-    namespace Pordio;
+    namespace App;
     
     use Jenssegers\Mongodb\Eloquent\Model;
     use Artesaos\Defender\Traits\Models\Permission;

--- a/README.md
+++ b/README.md
@@ -739,6 +739,7 @@ To use your own classes for Role and Permission models, first set the `role_mode
 
 Following are two examples of how Role and Permission models must be implemented for MongoDB using [jenssegers/laravel-mongodb](https://github.com/jenssegers/laravel-mongodb) driver:
 
+```php
     <?php
     
     // Role model
@@ -755,7 +756,9 @@ Following are two examples of how Role and Permission models must be implemented
     class Role extends Model implements RoleInterface {
         use Role;
     }
+```
 
+```php
     <?php
     
     // Permission model
@@ -773,5 +776,6 @@ Following are two examples of how Role and Permission models must be implemented
     {
         use Permission;    
     }
+```
 
 You must use the correct traits and each class has to implemet the corresponding interface contract.

--- a/README.md
+++ b/README.md
@@ -732,3 +732,46 @@ public function foo()
 
 It's also possible to extend an existing temporary:
 Just use the `$user->extendPermission($permissionName, array $options)` method.
+
+## Using custom Role and Permission models
+
+To use your own classes for Role and Permission models, first set the `role_model` and `permission_model` keys at `defender.php` config.
+
+Following are two examples of how Role and Permission models must be implemented for MongoDB using [jenssegers/laravel-mongodb](https://github.com/jenssegers/laravel-mongodb) driver:
+
+    <?php
+    
+    // Role model
+    
+    namespace Pordio;
+    
+    use Jenssegers\Mongodb\Eloquent\Model;
+    use Artesaos\Defender\Traits\Models\Role;
+    use Artesaos\Defender\Contracts\Role as RoleInterface;
+    
+    /**
+     * Class Role.
+     */
+    class Role extends Model implements RoleInterface {
+        use Role;
+    }
+
+    <?php
+    
+    // Permission model
+    
+    namespace Pordio;
+    
+    use Jenssegers\Mongodb\Eloquent\Model;
+    use Artesaos\Defender\Traits\Models\Permission;
+    use Artesaos\Defender\Contracts\Permission as PermissionInterface;
+    
+    /**
+     * Class Permission.
+     */
+    class Permission extends Model implements PermissionInterface
+    {
+        use Permission;    
+    }
+
+You must use the correct traits and each class has to implemet the corresponding interface contract.

--- a/src/Defender/Contracts/Permission.php
+++ b/src/Defender/Contracts/Permission.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Artesaos\Defender\Contracts;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Interface Permission.
+ */
+interface Permission
+{
+    /**
+     * Many-to-many permission-role relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function roles();
+
+    /**
+     * Many-to-many permission-user relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function users();
+
+    /**
+     * @param Model  $parent
+     * @param array  $attributes
+     * @param string $table
+     * @param bool   $exists
+     *
+     * @return PermissionUserPivot|\Illuminate\Database\Eloquent\Relations\Pivot
+     */
+    public function newPivot(Model $parent, array $attributes, $table, $exists);
+}

--- a/src/Defender/Contracts/Role.php
+++ b/src/Defender/Contracts/Role.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Artesaos\Defender\Contracts;
+
+/**
+ * Interface Role.
+ */
+interface Role
+{
+    /**
+     * Many-to-many role-user relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function users();
+}

--- a/src/Defender/Permission.php
+++ b/src/Defender/Permission.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Artesaos\Defender\Traits\Models\Permission;
 
 /**
- * Class Permission
+ * Class Permission.
  */
 class Permission extends Model implements Contracts\Permission
 {

--- a/src/Defender/Permission.php
+++ b/src/Defender/Permission.php
@@ -10,5 +10,5 @@ use Artesaos\Defender\Traits\Models\Permission;
  */
 class Permission extends Model implements Contracts\Permission
 {
-    use Permission;    
+    use Permission;
 }

--- a/src/Defender/Permission.php
+++ b/src/Defender/Permission.php
@@ -3,87 +3,12 @@
 namespace Artesaos\Defender;
 
 use Illuminate\Database\Eloquent\Model;
-use Artesaos\Defender\Pivots\PermissionRolePivot;
-use Artesaos\Defender\Pivots\PermissionUserPivot;
+use Artesaos\Defender\Traits\Models\Permission;
 
 /**
  * Class Permission.
  */
-class Permission extends Model
+class Permission extends Model implements Contracts\Permission
 {
-    /**
-     * @var
-     */
-    protected $table;
-
-    /**
-     * @var array
-     */
-    protected $fillable = [
-        'name',
-        'readable_name',
-    ];
-
-    /**
-     * @param array $attributes
-     */
-    public function __construct(array $attributes = [])
-    {
-        parent::__construct($attributes);
-        $this->table = config('defender.permission_table', 'permissions');
-    }
-
-    /**
-     * Many-to-many permission-role relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
-     */
-    public function roles()
-    {
-        return $this->belongsToMany(
-            config('defender.role_model'),
-            config('defender.permission_role_table'),
-            config('defender.permission_key'),
-            config('defender.role_key')
-        )->withPivot('value', 'expires');
-    }
-
-    /**
-     * Many-to-many permission-user relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
-     */
-    public function users()
-    {
-        return $this->belongsToMany(
-            config('defender.user_model'),
-            config('defender.permission_user_table'),
-            config('defender.permission_key'),
-            'user_id'
-        )->withPivot('value', 'expires');
-    }
-
-    /**
-     * @param Model  $parent
-     * @param array  $attributes
-     * @param string $table
-     * @param bool   $exists
-     *
-     * @return PermissionUserPivot|\Illuminate\Database\Eloquent\Relations\Pivot
-     */
-    public function newPivot(Model $parent, array $attributes, $table, $exists)
-    {
-        $userModel = app()['config']->get('defender.user_model');
-        $roleModel = app()['config']->get('defender.role_model');
-
-        if ($parent instanceof $userModel) {
-            return new PermissionUserPivot($parent, $attributes, $table, $exists);
-        }
-
-        if ($parent instanceof $roleModel) {
-            return new PermissionRolePivot($parent, $attributes, $table, $exists);
-        }
-
-        return parent::newPivot($parent, $attributes, $table, $exists);
-    }
+    use Permission;    
 }

--- a/src/Defender/Permission.php
+++ b/src/Defender/Permission.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Artesaos\Defender\Traits\Models\Permission;
 
 /**
- * Class Permission.
+ * Class Permission
  */
 class Permission extends Model implements Contracts\Permission
 {

--- a/src/Defender/Providers/DefenderServiceProvider.php
+++ b/src/Defender/Providers/DefenderServiceProvider.php
@@ -88,7 +88,7 @@ class DefenderServiceProvider extends ServiceProvider
 
         $this->app->singleton('defender.permission', function ($app) {
             $permissionModel = $app['config']->get('defender.permission_model');
-            
+
             return new EloquentPermissionRepository($app, $app->make($permissionModel));
         });
 

--- a/src/Defender/Providers/DefenderServiceProvider.php
+++ b/src/Defender/Providers/DefenderServiceProvider.php
@@ -2,10 +2,8 @@
 
 namespace Artesaos\Defender\Providers;
 
-use Artesaos\Defender\Role;
 use Artesaos\Defender\Defender;
 use Artesaos\Defender\Javascript;
-use Artesaos\Defender\Permission;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
 use Artesaos\Defender\Repositories\Eloquent\EloquentRoleRepository;
@@ -79,7 +77,9 @@ class DefenderServiceProvider extends ServiceProvider
     protected function registerRepositoryInterfaces()
     {
         $this->app->singleton('defender.role', function ($app) {
-            return new EloquentRoleRepository($app, new Role());
+            $roleModel = $app['config']->get('defender.role_model');
+
+            return new EloquentRoleRepository($app, $app->make($roleModel));
         });
 
         $this->app->singleton('Artesaos\Defender\Contracts\Repositories\RoleRepository', function ($app) {
@@ -87,7 +87,9 @@ class DefenderServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton('defender.permission', function ($app) {
-            return new EloquentPermissionRepository($app, new Permission());
+            $permissionModel = $app['config']->get('defender.permission_model');
+            
+            return new EloquentPermissionRepository($app, $app->make($permissionModel));
         });
 
         $this->app->singleton('Artesaos\Defender\Contracts\Repositories\PermissionRepository', function ($app) {

--- a/src/Defender/Repositories/Eloquent/EloquentPermissionRepository.php
+++ b/src/Defender/Repositories/Eloquent/EloquentPermissionRepository.php
@@ -2,7 +2,7 @@
 
 namespace Artesaos\Defender\Repositories\Eloquent;
 
-use Artesaos\Defender\Permission;
+use Artesaos\Defender\Contracts\Permission;
 use Illuminate\Contracts\Foundation\Application;
 use Artesaos\Defender\Exceptions\PermissionExistsException;
 use Artesaos\Defender\Contracts\Repositories\PermissionRepository;

--- a/src/Defender/Repositories/Eloquent/EloquentRoleRepository.php
+++ b/src/Defender/Repositories/Eloquent/EloquentRoleRepository.php
@@ -2,7 +2,8 @@
 
 namespace Artesaos\Defender\Repositories\Eloquent;
 
-use Artesaos\Defender\Role;
+use Artesaos\Defender\Contracts\Role;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Contracts\Foundation\Application;
 use Artesaos\Defender\Exceptions\RoleExistsException;
 use Artesaos\Defender\Contracts\Repositories\RoleRepository;

--- a/src/Defender/Role.php
+++ b/src/Defender/Role.php
@@ -3,53 +3,12 @@
 namespace Artesaos\Defender;
 
 use Illuminate\Database\Eloquent\Model;
-use Artesaos\Defender\Traits\Permissions\RoleHasPermissions;
+use Artesaos\Defender\Traits\Models\Role;
 
 /**
  * Class Role.
  */
-class Role extends Model
+class Role extends Model implements Contracts\Role
 {
-    use RoleHasPermissions;
-
-    /**
-     * Table name.
-     *
-     * @var string
-     */
-    protected $table;
-
-    /**
-     * Mass-assignment whitelist.
-     *
-     * @var array
-     */
-    protected $fillable = [
-        'name',
-    ];
-
-    /**
-     * @param array $attributes
-     */
-    public function __construct(array $attributes = [])
-    {
-        parent::__construct($attributes);
-
-        $this->table = config('defender.role_table', 'roles');
-    }
-
-    /**
-     * Many-to-many role-user relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
-     */
-    public function users()
-    {
-        return $this->belongsToMany(
-            config('defender.user_model'),
-            config('defender.role_user_table'),
-            config('defender.role_key'),
-            'user_id'
-        );
-    }
+    use Role;
 }

--- a/src/Defender/Traits/Models/Permission.php
+++ b/src/Defender/Traits/Models/Permission.php
@@ -21,9 +21,7 @@ trait Permission
      */
     public function __construct(array $attributes = [])
     {
-        /**
-         * Must to be declared before parent::__construct call
-         */
+         // Must to be declared before parent::__construct call
         $this->fillable = $fillable = [
             'name',
             'readable_name',

--- a/src/Defender/Traits/Models/Permission.php
+++ b/src/Defender/Traits/Models/Permission.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Artesaos\Defender\Traits\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Artesaos\Defender\Pivots\PermissionRolePivot;
+use Artesaos\Defender\Pivots\PermissionUserPivot;
+
+/**
+ * Trait Permission.
+ */
+trait Permission
+{
+    /**
+     * @var
+     */
+    protected $table;
+
+    /**
+     * @param array $attributes
+     */
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+        $this->table = config('defender.permission_table', 'permissions');
+        $this->fillable = $fillable = [
+            'name',
+            'readable_name',
+        ];
+    }
+
+    /**
+     * Many-to-many permission-role relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function roles()
+    {
+        return $this->belongsToMany(
+            config('defender.role_model'),
+            config('defender.permission_role_table'),
+            config('defender.permission_key'),
+            config('defender.role_key')
+        )->withPivot('value', 'expires');
+    }
+
+    /**
+     * Many-to-many permission-user relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function users()
+    {
+        return $this->belongsToMany(
+            config('defender.user_model'),
+            config('defender.permission_user_table'),
+            config('defender.permission_key'),
+            'user_id'
+        )->withPivot('value', 'expires');
+    }
+
+    /**
+     * @param Model  $parent
+     * @param array  $attributes
+     * @param string $table
+     * @param bool   $exists
+     *
+     * @return PermissionUserPivot|\Illuminate\Database\Eloquent\Relations\Pivot
+     */
+    public function newPivot(Model $parent, array $attributes, $table, $exists)
+    {
+        $userModel = app()['config']->get('defender.user_model');
+        $roleModel = app()['config']->get('defender.role_model');
+
+        if ($parent instanceof $userModel) {
+            return new PermissionUserPivot($parent, $attributes, $table, $exists);
+        }
+
+        if ($parent instanceof $roleModel) {
+            return new PermissionRolePivot($parent, $attributes, $table, $exists);
+        }
+
+        return parent::newPivot($parent, $attributes, $table, $exists);
+    }
+}

--- a/src/Defender/Traits/Models/Permission.php
+++ b/src/Defender/Traits/Models/Permission.php
@@ -21,12 +21,17 @@ trait Permission
      */
     public function __construct(array $attributes = [])
     {
-        parent::__construct($attributes);
-        $this->table = config('defender.permission_table', 'permissions');
+        /**
+         * Must to be declared before parent::__construct call
+         */
         $this->fillable = $fillable = [
             'name',
             'readable_name',
         ];
+
+        parent::__construct($attributes);
+
+        $this->table = config('defender.permission_table', 'permissions');
     }
 
     /**

--- a/src/Defender/Traits/Models/Permission.php
+++ b/src/Defender/Traits/Models/Permission.php
@@ -21,7 +21,7 @@ trait Permission
      */
     public function __construct(array $attributes = [])
     {
-         // Must to be declared before parent::__construct call
+        // Must to be declared before parent::__construct call
         $this->fillable = $fillable = [
             'name',
             'readable_name',

--- a/src/Defender/Traits/Models/Role.php
+++ b/src/Defender/Traits/Models/Role.php
@@ -23,12 +23,13 @@ trait Role
      */
     public function __construct(array $attributes = [])
     {
-        parent::__construct($attributes);
-
-        $this->table = config('defender.role_table', 'roles');
         $this->fillable = [
                 'name',
             ];
+
+        parent::__construct($attributes);
+
+        $this->table = config('defender.role_table', 'roles');
     }
 
     /**

--- a/src/Defender/Traits/Models/Role.php
+++ b/src/Defender/Traits/Models/Role.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Artesaos\Defender\Traits\Models;
+
+use Artesaos\Defender\Traits\Permissions\RoleHasPermissions;
+
+/**
+ * Trait Role.
+ */
+trait Role
+{
+    use RoleHasPermissions;
+
+    /**
+     * Table name.
+     *
+     * @var string
+     */
+    protected $table;
+
+    /**
+     * @param array $attributes
+     */
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->table = config('defender.role_table', 'roles');
+        $this->fillable = [
+                'name',
+            ];
+    }
+
+    /**
+     * Many-to-many role-user relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function users()
+    {
+        return $this->belongsToMany(
+            config('defender.user_model'),
+            config('defender.role_user_table'),
+            config('defender.role_key'),
+            'user_id'
+        );
+    }
+}

--- a/tests/stubs/models/User.php
+++ b/tests/stubs/models/User.php
@@ -12,8 +12,7 @@ use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 /**
  * Class User.
  */
-class User extends Model implements AuthenticatableContract,
-                                    CanResetPasswordContract
+class User extends Model implements AuthenticatableContract, CanResetPasswordContract
 {
     use Authenticatable, CanResetPassword, HasDefender;
 


### PR DESCRIPTION
This changes implement the need of creating Role and Permission classes from config file, mainly when custom model classes in an app are extending custom Eloquent drivers, as a MongoDB driver.

Implements #92 