### PR TITLE
Permission and Role interfaces are binded now to the config implementations

### DIFF
--- a/src/Defender/Providers/DefenderServiceProvider.php
+++ b/src/Defender/Providers/DefenderServiceProvider.php
@@ -77,13 +77,15 @@ class DefenderServiceProvider extends ServiceProvider
      */
     protected function registerRepositoryInterfaces()
     {
-        $this->app->bind('Artesaos\Defender\Contracts\Permission', 'Artesaos\Defender\Permission');
-        $this->app->bind('Artesaos\Defender\Contracts\Role', 'Artesaos\Defender\Role');
+        $this->app->bind('Artesaos\Defender\Contracts\Permission', function ($app) {
+            return $app->make($this->app['config']->get('defender.permission_model'));
+        });
+        $this->app->bind('Artesaos\Defender\Contracts\Role', function ($app) {
+            return $app->make($this->app['config']->get('defender.role_model'));
+        });
 
         $this->app->singleton('defender.role', function ($app) {
-            $roleModel = $app['config']->get('defender.role_model');
-
-            return new EloquentRoleRepository($app, $app->make($roleModel));
+            return new EloquentRoleRepository($app, $app->make(\Artesaos\Defender\Contracts\Role::class));
         });
 
         $this->app->singleton('Artesaos\Defender\Contracts\Repositories\RoleRepository', function ($app) {
@@ -91,9 +93,7 @@ class DefenderServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton('defender.permission', function ($app) {
-            $permissionModel = $app['config']->get('defender.permission_model');
-
-            return new EloquentPermissionRepository($app, $app->make($permissionModel));
+            return new EloquentPermissionRepository($app, $app->make(\Artesaos\Defender\Contracts\Permission::class));
         });
 
         $this->app->singleton('Artesaos\Defender\Contracts\Repositories\PermissionRepository', function ($app) {

--- a/tests/Defender/AbstractTestCase.php
+++ b/tests/Defender/AbstractTestCase.php
@@ -135,6 +135,8 @@ abstract class AbstractTestCase extends TestCase
         ]);
 
         $app['config']->set('defender.user_model', 'Artesaos\Defender\Testing\User');
+        $app['config']->set('defender.role_model', 'Artesaos\Defender\Role');
+        $app['config']->set('defender.permission_model', 'Artesaos\Defender\Permission');
         $app['config']->set('auth.model', $app['config']->get('defender.user_model'));
     }
 

--- a/tests/Defender/DefenderServiceProviderTest.php
+++ b/tests/Defender/DefenderServiceProviderTest.php
@@ -26,6 +26,13 @@ class DefenderServiceProviderTest extends AbstractTestCase
         'testShouldNotLoadHelpers',
     ];
 
+    public function testModelBindings()
+    {
+        $this->assertInstanceOf('Artesaos\Defender\Role', $this->app->make('Artesaos\Defender\Contracts\Role'));
+
+        $this->assertInstanceOf('Artesaos\Defender\Permission', $this->app->make('Artesaos\Defender\Contracts\Permission'));
+    }
+
     /**
      * Verify if all services are in service container.
      */
@@ -143,8 +150,6 @@ class DefenderServiceProviderTest extends AbstractTestCase
      */
     public function testShouldPublishConfigAndMigrations()
     {
-        //dd(config_path());
-
         $this->artisan('vendor:publish');
 
         $resourcesPath = __DIR__.'/../../src/resources';


### PR DESCRIPTION
Sorry, I accidentally binded the interfaces directly to the models of the package, refusing possible implementations that users can create and overwrite the originals via config file

This will be released as the hotfix `0.6.2`