### PR TITLE
Upgrade defender to laravel 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,7 @@ php:
   - 7.1
   - nightly
 
-matrix:
-    include:
-      - php: 5.6
-        env: setup=pre-5.3
-      - php: 7.1
-        env: setup=pre-5.3
-      - php: nightly
-        env: setup=pre-5.3
-      - php: hhvm
-        env: setup=pre-5.3
-
 before_script:
-  - if [[ $setup = 'pre-5.3' ]]; then travis_retry composer require --dev "orchestra/testbench=3.2.*"; fi
-  - if [[ $setup = 'pre-5.3' ]]; then travis_retry composer require "illuminate/contracts=5.2.*" "illuminate/http=5.2.*" "illuminate/support=5.2.*" "illuminate/database=5.2.*" "illuminate/view=5.2.*" --no-interaction; fi
   - travis_retry composer install --no-interaction --prefer-source --no-suggest
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ notifications:
 
 script:
 #  - vendor/bin/phpspec run -v
-  - phpunit --process-isolation
+  - vendor/bin/phpunit --process-isolation

--- a/composer.json
+++ b/composer.json
@@ -22,18 +22,19 @@
     }
   ],
   "require": {
-    "php": ">=5.5.9",
-    "illuminate/contracts": "~5.0",
-    "illuminate/http": "~5.0",
-    "illuminate/support": "~5.0",
-    "illuminate/database": "~5.0",
-    "illuminate/view": "~5.0"
+    "php": ">=5.6.4",
+    "illuminate/contracts": "~5.4",
+    "illuminate/http": "~5.4",
+    "illuminate/support": "~5.4",
+    "illuminate/database": "~5.4",
+    "illuminate/view": "~5.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.0",
+    "phpunit/phpunit": "~5.0",
     "phpspec/phpspec": "~2.1",
     "friendsofphp/php-cs-fixer": "~1.0",
-    "orchestra/testbench": "~3.0",
+    "orchestra/testbench": "~3.4@dev",
+    "orchestra/database": "~3.4@dev",
     "fzaninotto/faker": "~1.5"
   },
   "autoload": {

--- a/src/Defender/Commands/MakePermission.php
+++ b/src/Defender/Commands/MakePermission.php
@@ -3,8 +3,8 @@
 namespace Artesaos\Defender\Commands;
 
 use Illuminate\Console\Command;
-use Artesaos\Defender\Contracts\Repositories\UserRepository;
 use Artesaos\Defender\Contracts\Repositories\RoleRepository;
+use Artesaos\Defender\Contracts\Repositories\UserRepository;
 use Artesaos\Defender\Contracts\Repositories\PermissionRepository;
 
 /**

--- a/src/Defender/Contracts/Permission.php
+++ b/src/Defender/Contracts/Permission.php
@@ -2,6 +2,7 @@
 
 namespace Artesaos\Defender\Contracts;
 
+use Artesaos\Defender\Pivots\PermissionUserPivot;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -28,8 +29,9 @@ interface Permission
      * @param array  $attributes
      * @param string $table
      * @param bool   $exists
+     * @param  string|null  $using
      *
      * @return PermissionUserPivot|\Illuminate\Database\Eloquent\Relations\Pivot
      */
-    public function newPivot(Model $parent, array $attributes, $table, $exists);
+    public function newPivot(Model $parent, array $attributes, $table, $exists, $using = null);
 }

--- a/src/Defender/Contracts/Permission.php
+++ b/src/Defender/Contracts/Permission.php
@@ -2,8 +2,8 @@
 
 namespace Artesaos\Defender\Contracts;
 
-use Artesaos\Defender\Pivots\PermissionUserPivot;
 use Illuminate\Database\Eloquent\Model;
+use Artesaos\Defender\Pivots\PermissionUserPivot;
 
 /**
  * Interface Permission.

--- a/src/Defender/Repositories/Eloquent/EloquentPermissionRepository.php
+++ b/src/Defender/Repositories/Eloquent/EloquentPermissionRepository.php
@@ -2,11 +2,11 @@
 
 namespace Artesaos\Defender\Repositories\Eloquent;
 
+use Carbon\Carbon;
 use Artesaos\Defender\Contracts\Permission;
 use Illuminate\Contracts\Foundation\Application;
 use Artesaos\Defender\Exceptions\PermissionExistsException;
 use Artesaos\Defender\Contracts\Repositories\PermissionRepository;
-use Carbon\Carbon;
 
 /**
  * Class EloquentPermissionRepository.

--- a/src/Defender/Traits/Models/Permission.php
+++ b/src/Defender/Traits/Models/Permission.php
@@ -62,20 +62,21 @@ trait Permission
      * @param array  $attributes
      * @param string $table
      * @param bool   $exists
+     * @param  string|null  $using
      *
      * @return PermissionUserPivot|\Illuminate\Database\Eloquent\Relations\Pivot
      */
-    public function newPivot(Model $parent, array $attributes, $table, $exists)
+    public function newPivot(Model $parent, array $attributes, $table, $exists, $using = null)
     {
         $userModel = app()['config']->get('defender.user_model');
         $roleModel = app()['config']->get('defender.role_model');
 
         if ($parent instanceof $userModel) {
-            return new PermissionUserPivot($parent, $attributes, $table, $exists);
+            return new PermissionUserPivot($parent, $attributes, $table, $exists, $using);
         }
 
         if ($parent instanceof $roleModel) {
-            return new PermissionRolePivot($parent, $attributes, $table, $exists);
+            return new PermissionRolePivot($parent, $attributes, $table, $exists, $using);
         }
 
         return parent::newPivot($parent, $attributes, $table, $exists);

--- a/src/Defender/Traits/Permissions/RoleHasPermissions.php
+++ b/src/Defender/Traits/Permissions/RoleHasPermissions.php
@@ -32,17 +32,18 @@ trait RoleHasPermissions
      * @param array  $attributes
      * @param string $table
      * @param bool   $exists
+     * @param  string|null  $using
      *
      * @return PermissionRolePivot|\Illuminate\Database\Eloquent\Relations\Pivot
      */
-    public function newPivot(Model $parent, array $attributes, $table, $exists)
+    public function newPivot(Model $parent, array $attributes, $table, $exists, $using=null)
     {
         $permissionModel = app()['config']->get('defender.permission_model');
 
         if ($parent instanceof $permissionModel) {
-            return new PermissionRolePivot($parent, $attributes, $table, $exists);
+            return new PermissionRolePivot($parent, $attributes, $table, $exists, $using);
         }
 
-        return parent::newPivot($parent, $attributes, $table, $exists);
+        return parent::newPivot($parent, $attributes, $table, $exists, $using);
     }
 }

--- a/src/Defender/Traits/Permissions/RoleHasPermissions.php
+++ b/src/Defender/Traits/Permissions/RoleHasPermissions.php
@@ -36,7 +36,7 @@ trait RoleHasPermissions
      *
      * @return PermissionRolePivot|\Illuminate\Database\Eloquent\Relations\Pivot
      */
-    public function newPivot(Model $parent, array $attributes, $table, $exists, $using=null)
+    public function newPivot(Model $parent, array $attributes, $table, $exists, $using = null)
     {
         $permissionModel = app()['config']->get('defender.permission_model');
 

--- a/src/Defender/Traits/Users/HasPermissions.php
+++ b/src/Defender/Traits/Users/HasPermissions.php
@@ -33,17 +33,18 @@ trait HasPermissions
      * @param array  $attributes
      * @param string $table
      * @param bool   $exists
+     * @param  string|null  $using
      *
      * @return PermissionUserPivot
      */
-    public function newPivot(Model $parent, array $attributes, $table, $exists)
+    public function newPivot(Model $parent, array $attributes, $table, $exists, $using=null)
     {
         $permissionModel = app()['config']->get('defender.permission_model');
 
         if ($parent instanceof $permissionModel) {
-            return new PermissionUserPivot($parent, $attributes, $table, $exists);
+            return new PermissionUserPivot($parent, $attributes, $table, $exists, $using);
         }
 
-        return parent::newPivot($parent, $attributes, $table, $exists);
+        return parent::newPivot($parent, $attributes, $table, $exists, $using);
     }
 }

--- a/src/Defender/Traits/Users/HasPermissions.php
+++ b/src/Defender/Traits/Users/HasPermissions.php
@@ -37,7 +37,7 @@ trait HasPermissions
      *
      * @return PermissionUserPivot
      */
-    public function newPivot(Model $parent, array $attributes, $table, $exists, $using=null)
+    public function newPivot(Model $parent, array $attributes, $table, $exists, $using = null)
     {
         $permissionModel = app()['config']->get('defender.permission_model');
 

--- a/tests/Defender/AbstractTestCase.php
+++ b/tests/Defender/AbstractTestCase.php
@@ -30,7 +30,7 @@ abstract class AbstractTestCase extends TestCase
         $paths = is_array($path) ? $path : [$path];
 
         foreach ($paths as $path) {
-            $this->loadMigrationsFrom(['--realpath' => $path]);
+            $this->loadMigrationsFrom($path);
         }
     }
 

--- a/tests/Defender/AbstractTestCase.php
+++ b/tests/Defender/AbstractTestCase.php
@@ -30,19 +30,7 @@ abstract class AbstractTestCase extends TestCase
         $paths = is_array($path) ? $path : [$path];
 
         foreach ($paths as $path) {
-            $code = $this->artisan(
-                'migrate',
-                ['--realpath' => $path]
-            );
-
-            $this->assertEquals(
-                0,
-                $code,
-                sprintf(
-                    'Something went wrong when migrating %s.',
-                    str_replace(realpath($this->srcPath('..')), '', realpath($path))
-                )
-            );
+            $this->loadMigrationsFrom(['--realpath' => $path]);
         }
     }
 

--- a/tests/Defender/CommandsTest.php
+++ b/tests/Defender/CommandsTest.php
@@ -39,6 +39,7 @@ class CommandsTest extends AbstractTestCase
     {
         return [
             'Artesaos\Defender\Providers\DefenderServiceProvider',
+            'Orchestra\Database\ConsoleServiceProvider',
         ];
     }
 
@@ -49,7 +50,7 @@ class CommandsTest extends AbstractTestCase
     {
         $this->artisan('defender:make:permission', ['name' => 'a.permission', 'readableName' => 'A permission.']);
 
-        $this->seeInDatabase(
+        $this->assertDatabaseHas(
             config('defender.permission_table', 'permissions'),
             [
                 'name' => 'a.permission',
@@ -65,7 +66,7 @@ class CommandsTest extends AbstractTestCase
     {
         $this->artisan('defender:make:permission', ['name' => 'user.index', 'readableName' => 'List Users', '--user' => 1]);
 
-        $this->seeInDatabase(
+        $this->assertDatabaseHas(
             config('defender.permission_table', 'permissions'),
             [
                 'name' => 'user.index',
@@ -84,7 +85,7 @@ class CommandsTest extends AbstractTestCase
     public function testCommandShouldMakeAPermissionToRole()
     {
         $this->artisan('defender:make:permission', ['name' => 'user.delete', 'readableName' => 'Remove Users', '--role' => 'admin']);
-        $this->seeInDatabase(
+        $this->assertDatabaseHas(
             config('defender.permission_table', 'permissions'),
             [
                 'name' => 'user.delete',
@@ -108,7 +109,7 @@ class CommandsTest extends AbstractTestCase
     {
         $this->artisan('defender:make:role', ['name' => 'a.role']);
 
-        $this->seeInDatabase(
+        $this->assertDatabaseHas(
             config('defender.role_table', 'roles'),
             [
                 'name' => 'a.role',
@@ -123,7 +124,7 @@ class CommandsTest extends AbstractTestCase
     {
         $this->artisan('defender:make:role', ['name' => 'user.role', '--user' => 1]);
 
-        $this->seeInDatabase(
+        $this->assertDatabaseHas(
             config('defender.role_table', 'roles'),
             [
                 'name' => 'user.role',

--- a/tests/Defender/CommandsTest.php
+++ b/tests/Defender/CommandsTest.php
@@ -6,6 +6,7 @@
  * Date: 12/07/15
  * Time: 01:01.
  */
+
 namespace Artesaos\Defender\Testing;
 
 use Artesaos\Defender\Role;

--- a/tests/Defender/EloquentPermissionRepositoryTest.php
+++ b/tests/Defender/EloquentPermissionRepositoryTest.php
@@ -17,6 +17,7 @@ class EloquentPermissionRepositoryTest extends AbstractTestCase
      */
     protected $providers = [
         'Artesaos\Defender\Providers\DefenderServiceProvider',
+        'Orchestra\Database\ConsoleServiceProvider',
     ];
 
     /**
@@ -125,7 +126,7 @@ class EloquentPermissionRepositoryTest extends AbstractTestCase
             $where['readable_name'] = $readableName;
         }
 
-        $this->seeInDatabase(
+        $this->assertDatabaseHas(
             config('defender.permission_table', 'permissions'),
             $where
         );
@@ -184,7 +185,7 @@ class EloquentPermissionRepositoryTest extends AbstractTestCase
      */
     protected function seePermissionAttachedToUserInDatabase(Permission $permission, User $user)
     {
-        $this->seeInDatabase(
+        $this->assertDatabaseHas(
             config('defender.permission_user_table', 'permission_user'),
             [
                 config('defender.permission_key', 'permission_id') => $permission->id,

--- a/tests/Defender/EloquentPermissionRepositoryTest.php
+++ b/tests/Defender/EloquentPermissionRepositoryTest.php
@@ -201,7 +201,7 @@ class EloquentPermissionRepositoryTest extends AbstractTestCase
      */
     protected function notSeePermissionAttachedToUserInDatabase(Permission $permission, User $user)
     {
-        $this->notSeeInDatabase(
+        $this->assertDatabaseMissing(
             config('defender.permission_user_table', 'permission_user'),
             [
                 config('defender.permission_key', 'permission_id') => $permission->id,
@@ -217,7 +217,7 @@ class EloquentPermissionRepositoryTest extends AbstractTestCase
      */
     protected function seePermissionAttachedToRoleInDatabase(Permission $permission, Role $role)
     {
-        $this->seeInDatabase(
+        $this->assertDatabaseHas(
             config('defender.permission_role_table', 'permission_role'),
             [
                 config('defender.permission_key', 'permission_id') => $permission->id,
@@ -233,7 +233,7 @@ class EloquentPermissionRepositoryTest extends AbstractTestCase
      */
     protected function notSeePermissionAttachedToRoleInDatabase(Permission $permission, Role $role)
     {
-        $this->notSeeInDatabase(
+        $this->assertDatabaseMissing(
             config('defender.permission_role_table', 'permission_role'),
             [
                 config('defender.permission_key', 'permission_id') => $permission->id,

--- a/tests/Defender/EloquentPermissionRepositoryTest.php
+++ b/tests/Defender/EloquentPermissionRepositoryTest.php
@@ -2,9 +2,9 @@
 
 namespace Artesaos\Defender\Testing;
 
+use Artesaos\Defender\Role;
 use Artesaos\Defender\Permission;
 use Artesaos\Defender\Repositories\Eloquent\EloquentPermissionRepository;
-use Artesaos\Defender\Role;
 
 /**
  * Class EloquentPermissionRepositoryTest.

--- a/tests/Defender/EloquentRoleRepositoryTest.php
+++ b/tests/Defender/EloquentRoleRepositoryTest.php
@@ -17,6 +17,7 @@ class EloquentRoleRepositoryTest extends AbstractTestCase
      */
     protected $providers = [
         'Artesaos\Defender\Providers\DefenderServiceProvider',
+        'Orchestra\Database\ConsoleServiceProvider',
     ];
 
     /**

--- a/tests/Defender/EloquentRoleRepositoryTest.php
+++ b/tests/Defender/EloquentRoleRepositoryTest.php
@@ -107,7 +107,7 @@ class EloquentRoleRepositoryTest extends AbstractTestCase
 
         $role = $repository->create($rolename);
 
-        $this->seeInDatabase(
+        $this->assertDatabaseHas(
             config('defender.role_table', 'roles'),
             ['name' => $rolename]
         );
@@ -143,7 +143,7 @@ class EloquentRoleRepositoryTest extends AbstractTestCase
      */
     protected function seeRoleAttachedToUserInDatabase(Role $role, User $user)
     {
-        $this->seeInDatabase(
+        $this->assertDatabaseHas(
             config('defender.role_user_table', 'role_user'),
             [
                 config('defender.role_key', 'role_id') => $role->id,
@@ -159,7 +159,7 @@ class EloquentRoleRepositoryTest extends AbstractTestCase
      */
     protected function notSeeRoleAttachedToUserInDatabase(Role $role, User $user)
     {
-        $this->notSeeInDatabase(
+        $this->assertDatabaseMissing(
             config('defender.role_user_table', 'role_user'),
             [
                 config('defender.role_key', 'role_id') => $role->id,

--- a/tests/Defender/EloquentRoleRepositoryTest.php
+++ b/tests/Defender/EloquentRoleRepositoryTest.php
@@ -2,9 +2,9 @@
 
 namespace Artesaos\Defender\Testing;
 
-use Artesaos\Defender\Contracts\Repositories\RoleRepository;
 use Artesaos\Defender\Role;
 use Illuminate\Database\Eloquent\Collection;
+use Artesaos\Defender\Contracts\Repositories\RoleRepository;
 
 /**
  * Class EloquentRoleRepositoryTest.

--- a/tests/Defender/JavascriptTest.php
+++ b/tests/Defender/JavascriptTest.php
@@ -13,7 +13,10 @@ class JavascriptTest extends AbstractTestCase
      * Array of service providers.
      * @var array
      */
-    protected $providers = ['Artesaos\Defender\Providers\DefenderServiceProvider'];
+    protected $providers = [
+        'Artesaos\Defender\Providers\DefenderServiceProvider',
+        'Orchestra\Database\ConsoleServiceProvider',
+    ];
 
     /**
      * New defender instance.

--- a/tests/Defender/MigrationsTest.php
+++ b/tests/Defender/MigrationsTest.php
@@ -13,6 +13,7 @@ class MigrationsTest extends AbstractTestCase
      */
     protected $providers = [
         'Artesaos\Defender\Providers\DefenderServiceProvider',
+        'Orchestra\Database\ConsoleServiceProvider',
     ];
 
     /**

--- a/tests/stubs/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/tests/stubs/database/migrations/2014_10_12_000000_create_users_table.php
@@ -1,7 +1,7 @@
 <?php
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 class CreateUsersTable extends Migration
 {


### PR DESCRIPTION
This MR intents to upgrade the defender package to laravel 5.4.

Unfortunately are some breaking changes on 5.4 which obliges us to introduce a new version incompatible with previous framework versions.

Laravel <= 5.3 should use `0.6.*` and 5.4 the new `0.7` that will be introduced as soon as the tests pass

The tests are not passing at this point so any help with the remaining errors will be appreciated