### PR TITLE
Fix permissions with false value.

### DIFF
--- a/src/Defender/Repositories/Eloquent/EloquentPermissionRepository.php
+++ b/src/Defender/Repositories/Eloquent/EloquentPermissionRepository.php
@@ -76,4 +76,22 @@ class EloquentPermissionRepository extends AbstractEloquentRepository implements
             })
             ->get();
     }
+
+	/**
+	 * @param $user
+	 *
+	 * @return \Illuminate\Database\Eloquent\Collection
+	 */
+	public function getInactivesByUser($user)
+	{
+		$table = $user->permissions()->getTable();
+
+		return $user->permissions()
+			->where($table.'.value', false)
+			->where(function ($q) use ($table) {
+				$q->where($table.'.expires', '>=', Carbon::now());
+				$q->orWhereNull($table.'.expires');
+			})
+			->get();
+	}
 }

--- a/src/Defender/Traits/HasDefender.php
+++ b/src/Defender/Traits/HasDefender.php
@@ -158,13 +158,16 @@ trait HasDefender
         $permissionsRoles = $this->getRolesPermissions(true);
 
         $permissions = app('defender.permission')->getActivesByUser($this);
+	    $permissionsInactives = app('defender.permission')->getInactivesByUser($this);
 
         $permissions = $permissions->merge($permissionsRoles)
-            ->map(function ($permission) {
-                unset($permission->pivot, $permission->created_at, $permission->updated_at);
+            ->map(function ($permission) use($permissionsInactives) {
+	            unset($permission->pivot, $permission->created_at, $permission->updated_at);
 
-                return $permission;
-            });
+	            if(!$permissionsInactives->whereIn('id', $permission->id)->first()){
+		            return $permission;
+	            }
+            })->filter();
 
         return $permissions->toBase();
     }


### PR DESCRIPTION
On a proposal, Defender should deny a permission with a value equal to false, but the same was not happening when using `@shield () ',' canDo () 'or' hasPermission () '. So I made a small change to solve this problem.