### PR TITLE
Prepare release 0.7

### DIFF
--- a/README-pt_BR.md
+++ b/README-pt_BR.md
@@ -30,10 +30,15 @@ Com Segurança e Usabilidade em mente, este projeto tem como objetivo prover o c
 ### 1. Dependência
 
 Defender pode ser instalado através do <a href="https://getcomposer.org/" target="_blank">composer</a>.
-Para que o package seja adicionado automaticamente ao seu arquivo `composer.json` execute o seguinte comando:
+Para que o package seja adicionado automaticamente ao seu arquivo `composer.json` execute o seguinte comando utilizando a versão do pacote correspondente:
+
+| Versão Laravel       | Versão do Pacote |
+|----------------------|------------------|
+| >= 5.0.* && <= 5.3.* | 0.6.*            |
+| ~5.4, ~5.5           | 0.7.*            |
 
 ```shell
-composer require artesaos/defender
+composer require artesaos/defender `versao-pacote`
 ```
 
 ou se preferir, adicione o seguinte trecho manualmente:
@@ -41,12 +46,14 @@ ou se preferir, adicione o seguinte trecho manualmente:
 ```json
 {
 	"require": {
-		"artesaos/defender": "~0.6"
+		"artesaos/defender": "versao-pacote"
 	}
 }
 ```
 
 ### 2. Provider
+
+> Se você está utilizando Laravel 5.5+ essa seção não é necessária pois o pacote suporta a função de auto-discovery.
 
 Para usar o Defender em sua aplicação Laravel, é necessário registrar o package no seu arquivo `config/app.php`. Adicione o seguinte código no fim da seção `providers`
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [Readme em Português](https://github.com/artesaos/defender/blob/master/README-pt_BR.md).
 
-Defender is a Access Control List (ACL) Solution for Laravel 5.* (single auth). **(Not compatible with multi-auth)**  
+Defender is an Access Control List (ACL) Solution for Laravel 5.* (single auth). **(Not compatible with multi-auth)**  
 With security and usability in mind, this project aims to provide you a safe way to control your application access without losing the fun of coding.
 
 > Current Build Status
@@ -28,10 +28,15 @@ With security and usability in mind, this project aims to provide you a safe way
 
 ### 1. Dependency
 
-Using <a href="https://getcomposer.org/" target="_blank">composer</a>, execute the following command to automatically update your `composer.json`:
+Using <a href="https://getcomposer.org/" target="_blank">composer</a>, execute the following command to automatically update your `composer.json`, using the corresponding package version:
+
+| Version Constraint   | Package Version  |
+|----------------------|------------------|
+| >= 5.0.* && <= 5.3.* | 0.6.*            |
+| ~5.4, ~5.5           | 0.7.*            |
 
 ```shell
-composer require artesaos/defender
+composer require artesaos/defender `package-version`
 ```
 
 or manually update your `composer.json` file
@@ -39,12 +44,14 @@ or manually update your `composer.json` file
 ```json
 {
     "require": {
-        "artesaos/defender": "~0.6"
+        "artesaos/defender": "package-version"
     }
 }
 ```
 
 ### 2. Provider
+
+> If you are using Laravel 5.5+ skip this section since our package support auto-discovery.
 
 You need to update your application configuration in order to register the package, so it can be loaded by Laravel. Just update your `config/app.php` file adding the following code at the end of your `'providers'` section:
 

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
   ],
   "require": {
     "php": ">=5.6.4",
-    "illuminate/contracts": "~5.4",
-    "illuminate/http": "~5.4",
-    "illuminate/support": "~5.4",
-    "illuminate/database": "~5.4",
-    "illuminate/view": "~5.4"
+    "illuminate/contracts": "~5.4 || ~5.5",
+    "illuminate/http": "~5.4 || ~5.5",
+    "illuminate/support": "~5.4 || ~5.5",
+    "illuminate/database": "~5.4 || ~5.5",
+    "illuminate/view": "~5.4 || ~5.5"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.0",


### PR DESCRIPTION
I recently migrated an app from Laravel 5.4 to 5.5 and the package worked as expected with no major issues. Version 0.7 will be tagged for these versions of the framework.