### PR TITLE
Updated to PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - nightly

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   ],
   "require": {
-    "php": ">=5.6.4",
+    "php": ">=7.0.0",
     "illuminate/contracts": "~5.4 || ~5.5",
     "illuminate/http": "~5.4 || ~5.5",
     "illuminate/support": "~5.4 || ~5.5",
@@ -30,7 +30,7 @@
     "illuminate/view": "~5.4 || ~5.5"
   },
   "require-dev": {
-    "phpunit/phpunit": "~5.0",
+    "phpunit/phpunit": "~6.4",
     "phpspec/phpspec": "~2.1",
     "friendsofphp/php-cs-fixer": "~1.0",
     "orchestra/testbench": "~3.4@dev",


### PR DESCRIPTION
Updated `phpunit/phpunit` to `~6.0`.

Dropped support to `PHP 5.6`, as PHPUnit 6.0 [requires PHP 7.0](https://github.com/sebastianbergmann/phpunit/blob/master/composer.json#L25).